### PR TITLE
Feature/134249301/log past games

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -737,7 +737,7 @@ div.notification_body {
   cursor: default;
 }
 
-div.chatthread {
+/*div.chatthread {
   background: red;
   height: 340px;
   width: 320px;

--- a/public/views/app.html
+++ b/public/views/app.html
@@ -88,7 +88,6 @@
             </span>
         </a>
        <a id='game-history-button-mobile' ng-click="gameLog()" class="gameHistoryButton">
-          Game History
           <i class="material-icons" style="display: inline-block;float: right">&#xE889;</i>
           <span class="mdl-tooltip" data-mdl-for="game-history-button-mobile">
             Game <strong>History</strong>
@@ -301,7 +300,7 @@
   <h6 class="mdl-dialog__title" style="text-align:center">Game History</h6>
   <div class="mdl-dialog__content">
     <div class="table-responsive">
-      <table class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
+      <table style="margin-left:auto;margin-right:auto;" class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
         <thead>
           <tr>
             <th class="mdl-data-table__cell--non-numeric">
@@ -320,25 +319,25 @@
         </thead>
         <tbody>
           <tr ng-repeat="toDisplay in allGames">
-            <td class="mdl-data-table__cell--non-numeric">
+            <td style="text-align:center" class="mdl-data-table__cell--non-numeric">
               {{regexx.exec(toDisplay.started)[0]}}
             </td>
-            <td class="mdl-data-table__cell--non-numeric">
+            <td style="text-align:center" class="mdl-data-table__cell--non-numeric">
               <a ng-click="displayfriends = !displayfriends">
                   {{toDisplay.players.length}} players...
                 </a>
               <table ng-show='displayfriends'>
                 <tr ng-repeat="name in toDisplay.players">
-                  <td class="mdl-data-table__cell--non-numeric">
+                  <td style="text-align:center" class="mdl-data-table__cell--non-numeric">
                     {{name.username}}
                   </td>
                 </tr>
               </table>
             </td>
-            <td class="mdl-data-table__cell--non-numeric">
+            <td style="text-align:center" class="mdl-data-table__cell--non-numeric">
               {{toDisplay.rounds}}
             </td>
-            <td class="mdl-data-table__cell--non-numeric">
+            <td style="text-align:center" class="mdl-data-table__cell--non-numeric">
               {{toDisplay.winner}}
             </td>
           </tr>


### PR DESCRIPTION
#### What does this PR do?

Addresses Centering feedback in game log and fixes chat thread display background colour

#### Description of Task to be completed?

Text in the "Rounds" column  of game log should be centered

adjust CSS issue with chat thread
#### How should this be manually tested?

Click the Game History Button
Expand the chat window

#### Any background context you want to provide?

N/A

#### What are the relevant pivotal tracker stories?

#134249301- Users should be able view game log of past games

#### Screenshots (if appropriate)

N/A

#### Questions:

N/A